### PR TITLE
bug fix for `abs`

### DIFF
--- a/Numeric/Interval.hs
+++ b/Numeric/Interval.hs
@@ -135,7 +135,7 @@ instance (Num a, Ord a) => Num (Interval a) where
     abs x@(I a b) 
         | a >= 0    = x 
         | b <= 0    = negate x
-        | otherwise = max (- a) b ... b
+        | otherwise = 0 ... max (- a) b
 
     signum = increasing signum
 


### PR DESCRIPTION
I could just be misunderstanding something, but if you take the absolute value of a quantity on the interval [a,b] with a < 0 < b, then you get a quantity on the interval [0, max (-a) b], not [max (-a) b, b].
