### PR TITLE
Added clamp method for constraining a value to lie within an interval.

### DIFF
--- a/src/Numeric/Interval.hs
+++ b/src/Numeric/Interval.hs
@@ -40,6 +40,7 @@ module Numeric.Interval
   , isSubsetOf
   , certainly, (<!), (<=!), (==!), (>=!), (>!)
   , possibly, (<?), (<=?), (==?), (>=?), (>?)
+  , clamp
   , idouble
   , ifloat
   ) where
@@ -720,6 +721,12 @@ possibly cmp l r
         eq = cmp EQ EQ
         gt = cmp GT EQ
 {-# INLINE possibly #-}
+
+-- | The nearest value to that supplied which is contained in the interval.
+clamp :: Ord a => Interval a -> a -> a
+clamp (I a b) x | x < a     = a
+                | x > b     = b
+                | otherwise = x
 
 -- | id function. Useful for type specification
 --


### PR DESCRIPTION
I keep creating this function everywhere that I import intervals, so I thought I would see if you are interested in taking it. It is very commonly used in my control engineering/signal processing code; it may not be useful to your intended uses of the package.

I tried to match your coding and documentation style, I'm not sure how well I did.
