### PR TITLE
Changed clamp to return Nothing for an empty interval.

### DIFF
--- a/src/Numeric/Interval.hs
+++ b/src/Numeric/Interval.hs
@@ -40,7 +40,6 @@ module Numeric.Interval
   , isSubsetOf
   , certainly, (<!), (<=!), (==!), (>=!), (>!)
   , possibly, (<?), (<=?), (==?), (>=?), (>?)
-  , clamp
   , idouble
   , ifloat
   ) where
@@ -786,14 +785,6 @@ possibly cmp l r
         eq = cmp EQ EQ
         gt = cmp GT EQ
 {-# INLINE possibly #-}
-
--- | The nearest value to that supplied which is contained in the interval, or Nothing if the interval is empty.
-clamp :: Ord a => Interval a -> a -> Maybe a
-clamp (I a b) x
-  | x < a     = Just a
-  | x > b     = Just b
-  | otherwise = Just x
-clamp Empty _ = Nothing
 
 -- | id function. Useful for type specification
 --

--- a/src/Numeric/Interval/Kaucher.hs
+++ b/src/Numeric/Interval/Kaucher.hs
@@ -40,7 +40,6 @@ module Numeric.Interval.Kaucher
   , isSubsetOf
   , certainly, (<!), (<=!), (==!), (>=!), (>!)
   , possibly, (<?), (<=?), (==?), (>=?), (>?)
-  , clamp
   , idouble
   , ifloat
   ) where
@@ -719,12 +718,6 @@ possibly cmp l r
         eq = cmp EQ EQ
         gt = cmp GT EQ
 {-# INLINE possibly #-}
-
--- | The nearest value to that supplied which is contained in the interval.
-clamp :: Ord a => Interval a -> a -> a
-clamp (I a b) x | x < a     = a
-                | x > b     = b
-                | otherwise = x
 
 -- | id function. Useful for type specification
 --


### PR DESCRIPTION
I think it is probably a good idea to make the answer here explicitly a `Maybe`. That case is potentially very sneaky otherwise.

Alternatively it might be the case that this function only usefully exists in the `NonEmpty` module; I think it is the case that all my use sites of it will be switching to `NonEmpty`.
