### PR TITLE
Added measure of distance between intervals.

### DIFF
--- a/src/Numeric/Interval/NonEmpty.hs
+++ b/src/Numeric/Interval/NonEmpty.hs
@@ -30,6 +30,7 @@ module Numeric.Interval.NonEmpty
   , singular
   , width
   , midpoint
+  , distance
   , intersection
   , hull
   , bisect

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -29,6 +29,7 @@ module Numeric.Interval.NonEmpty.Internal
   , singular
   , width
   , midpoint
+  , distance
   , intersection
   , hull
   , bisect
@@ -246,6 +247,19 @@ bisectIntegral (I a b)
 midpoint :: Fractional a => Interval a -> a
 midpoint (I a b) = a + (b - a) / 2
 {-# INLINE midpoint #-}
+
+-- | Hausdorff distance between intervals.
+--
+-- >>> distance (1 ... 7) (6 ... 10)
+-- 0
+--
+-- >>> distance (1 ... 7) (15 ... 24)
+-- 8
+--
+-- >>> distance (1 ... 7) (-10 ... -2)
+-- 3
+distance :: (Num a, Ord a) => Interval a -> Interval a -> a
+distance i1 i2 = mignitude (i1 - i2)
 
 -- | Determine if a point is in the interval.
 --


### PR DESCRIPTION
This is what I was trying to do in the first place that led me to the issue with the old mignitude definition.

I'm not sure if it is of enough general interest to justify being here. But given the that I got it subtly wrong twice it might be.

I didn't add the same method to the empty of Kaucher variants because I wasn't sure how to handle one or both of the operands being `Empty`, or whether the directed definition had to be different somehow.
