### PR TITLE
Conservative trig functions

### DIFF
--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -104,10 +104,10 @@ periodic' r LT LT a b | a >= b = I b a -- stays in decreasing zone
                       | otherwise = r  -- goes from decreasing zone, all the way through increasing zone, and back to decreasing zone
 periodic' r GT _  a b = I (min a b) (sup r) -- was going up, started going down
 periodic' r LT _  a b = I (inf r) (max a b) -- was going down, started going up
-periodic' r EQ GT a b | a < b = I a b -- entirely within increasing zone
-                      | otherwise = r
-periodic' r EQ LT a b | a > b = I b a -- entirely within decreasing zone
-                      | otherwise = r
+periodic' r EQ GT a b | a < b = I a b -- stays in increasing zone
+                      | otherwise = r -- goes from increasing zone, all the way through decreasing zone, and back to increasing zone
+periodic' r EQ LT a b | a > b = I b a -- stays in decreasing zone
+                      | otherwise = r -- goes from decreasing zone, all the way through increasing zone, and back to decreasing zone
 periodic' _ _  _  a b = a ... b -- precisely begins and ends at local extremes, so it's either a singleton or whole
 
 -- | Create a non-empty interval, turning it around if necessary

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -104,7 +104,11 @@ periodic' r LT LT a b | a >= b = I b a -- stays in decreasing zone
                       | otherwise = r  -- goes from decreasing zone, all the way through increasing zone, and back to decreasing zone
 periodic' r GT _  a b = I (min a b) (sup r) -- was going up, started going down
 periodic' r LT _  a b = I (inf r) (max a b) -- was going down, started going up
-periodic' _ _  _  a b = a ... b -- precisely begins or ends at at least one local extreme
+periodic' r EQ GT a b | a < b = I a b -- entirely within increasing zone
+                      | otherwise = r
+periodic' r EQ LT a b | a > b = I b a -- entirely within decreasing zone
+                      | otherwise = r
+periodic' _ _  _  a b = a ... b -- precisely begins and ends at local extremes, so it's either a singleton or whole
 
 -- | Create a non-empty interval, turning it around if necessary
 (...) :: Ord a => a -> a -> Interval a

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -85,10 +85,13 @@ posInfinity :: Fractional a => a
 posInfinity = 1/0
 {-# INLINE posInfinity #-}
 
+-- the sign of a number, but as an Ordering so that we can pattern match over it.
+-- GT means greater than zero, etc.
 signum' :: (Ord a, Num a) => a -> Ordering
 signum' x = compare x 0
 
 -- arguments are period, range, derivative, function, and interval
+-- we require that each period of the function include precisely one local minimum and one local maximum
 periodic :: (Num a, Ord a) => a -> Interval a -> (a -> Ordering) -> (a -> a) -> Interval a -> Interval a
 periodic p r _ _ x | width x > p = r
 periodic _ r d f (I a b) = periodic' r (d a) (d b) (f a) (f b)
@@ -96,12 +99,12 @@ periodic _ r d f (I a b) = periodic' r (d a) (d b) (f a) (f b)
 -- arguments are global range, derivatives at endpoints, values at endpoints
 periodic' :: (Ord a) => Interval a -> Ordering -> Ordering -> a -> a -> Interval a
 periodic' r GT GT a b | a <= b = I a b -- stays in increasing zone
-                      | otherwise = r
+                      | otherwise = r  -- goes from increasing zone, all the way through decreasing zone, and back to increasing zone
 periodic' r LT LT a b | a >= b = I b a -- stays in decreasing zone
-                      | otherwise = r
+                      | otherwise = r  -- goes from decreasing zone, all the way through increasing zone, and back to decreasing zone
 periodic' r GT _  a b = I (min a b) (sup r) -- was going up, started going down
 periodic' r LT _  a b = I (inf r) (max a b) -- was going down, started going up
-periodic' _ _  _  a b = a ... b -- includes at least one max/min point
+periodic' _ _  _  a b = a ... b -- precisely begins or ends at at least one local extreme
 
 -- | Create a non-empty interval, turning it around if necessary
 (...) :: Ord a => a -> a -> Interval a

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -397,7 +397,7 @@ instance (RealFloat a, Ord a) => Floating (Interval a) where
   {-# INLINE log #-}
   sin = periodic (2 * pi) (symmetric 1) (signum' . cos)          sin
   cos = periodic (2 * pi) (symmetric 1) (signum' . negate . sin) cos
-  tan = periodic (2 * pi) whole         (const GT              ) tan -- derivative only has to have correct sign
+  tan = periodic (2 * pi) whole         (const GT)               tan -- derivative only has to have correct sign
   asin (I a b) = I (if a <= -1 then -halfPi else asin a) (if b >= 1 then halfPi else asin b)
     where halfPi = pi / 2
   {-# INLINE asin #-}

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -397,11 +397,19 @@ instance (RealFloat a, Ord a) => Floating (Interval a) where
   {-# INLINE log #-}
   sin = periodic (2 * pi) (symmetric 1) (signum' . cos)          sin
   cos = periodic (2 * pi) (symmetric 1) (signum' . negate . sin) cos
-  tan = periodic (2 * pi) whole         (const GT)               tan -- derivative only has to have correct sign
-  asin (I a b) = I (if a <= -1 then -halfPi else asin a) (if b >= 1 then halfPi else asin b)
-    where halfPi = pi / 2
+  tan = periodic pi       whole         (const GT)               tan -- derivative only has to have correct sign
+  asin (I a b) = (asin' a) ... (asin' b)
+    where 
+      asin' x | x >= 1 = halfPi
+              | x <= -1 = -halfPi
+              | otherwise = asin x
+      halfPi = pi / 2
   {-# INLINE asin #-}
-  acos (I a b) = I (if b >= 1 then 0 else acos b) (if a < -1 then pi else acos a)
+  acos (I a b) = (acos' a) ... (acos' b)
+    where
+      acos' x | x >= 1 = 0
+              | x <= -1 = pi
+              | otherwise = acos x
   {-# INLINE acos #-}
   atan = increasing atan
   {-# INLINE atan #-}
@@ -418,11 +426,16 @@ instance (RealFloat a, Ord a) => Floating (Interval a) where
   {-# INLINE tanh #-}
   asinh = increasing asinh
   {-# INLINE asinh #-}
-  acosh (I a b) = I lo $ acosh b
-    where lo | a <= 1 = 0
-             | otherwise = acosh a
+  acosh (I a b) = (acosh' a) ... (acosh' b)
+    where
+      acosh' x | x <= 1 = 0
+               | otherwise = acosh x
   {-# INLINE acosh #-}
-  atanh (I a b) = I (if a <= - 1 then negInfinity else atanh a) (if b >= 1 then posInfinity else atanh b)
+  atanh (I a b) = (atanh' a) ... (atanh' b)
+    where
+      atanh' x | x <= -1 = negInfinity
+               | x >= 1 = posInfinity
+               | otherwise = atanh x
   {-# INLINE atanh #-}
 
 -- | lift a monotone increasing function over a given interval


### PR DESCRIPTION
Fixes issue #20 and related issues.

I have doctests that test this, but they also test everything else (#4), and I didn't want to send up one pull request that was so huge.

See if you think that this approach can be modified to work for empty/kaucher intervals or whether you want to go a different way to address #20.