### PR TITLE
Remove Fractional constraint from intersection

### DIFF
--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -662,7 +662,7 @@ instance RealFloat a => RealFloat (Interval a) where
 --
 -- >>> intersection (1 ... 10 :: Interval Double) (5 ... 15 :: Interval Double)
 -- 5.0 ... 10.0
-intersection :: (Fractional a, Ord a) => Interval a -> Interval a -> Interval a
+intersection :: Ord a => Interval a -> Interval a -> Interval a
 intersection x@(I a b) y@(I a' b')
   | x /=! y   = Empty
   | otherwise = I (max a a') (min b b')

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -473,7 +473,7 @@ instance RealFloat a => RealFloat (Interval a) where
 --
 -- >>> intersection (1 ... 10 :: Interval Double) (5 ... 15 :: Interval Double)
 -- Just (5.0 ... 10.0)
-intersection :: (Fractional a, Ord a) => Interval a -> Interval a -> Maybe (Interval a)
+intersection :: Ord a => Interval a -> Interval a -> Maybe (Interval a)
 intersection x@(I a b) y@(I a' b')
   | x /=! y   = Nothing
   | otherwise = Just $ I (max a a') (min b b')


### PR DESCRIPTION
This patch removes unnecessary `Fractional a` constraint from `intersection` in `Numeric.Interval` and `Numeric.Interval.NonEmpty`.
