### PR TITLE
Hide Data.Foldable.null to avoid ambiguous references in Internal and Kaucher.

### DIFF
--- a/intervals.cabal
+++ b/intervals.cabal
@@ -1,5 +1,5 @@
 name:              intervals
-version:           0.7.0.1
+version:           0.7.0.2
 synopsis:          Interval Arithmetic
 description:
   A 'Numeric.Interval.Interval' is a closed, convex set of floating point values.

--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -52,7 +52,7 @@ module Numeric.Interval.Internal
 
 import Control.Exception as Exception
 import Data.Data
-import Data.Foldable hiding (minimum, maximum, elem, notElem)
+import Data.Foldable hiding (null, minimum, maximum, elem, notElem)
 import Data.Function (on)
 import Data.Monoid
 #if defined(__GLASGOW_HASKELL) && __GLASGOW_HASKELL__ >= 704

--- a/src/Numeric/Interval/Kaucher.hs
+++ b/src/Numeric/Interval/Kaucher.hs
@@ -53,7 +53,7 @@ import Control.Applicative hiding (empty)
 import Control.Exception as Exception
 import Data.Data
 import Data.Distributive
-import Data.Foldable hiding (minimum, maximum, elem, notElem)
+import Data.Foldable hiding (null, minimum, maximum, elem, notElem)
 import Data.Function (on)
 import Data.Monoid
 import Data.Traversable


### PR DESCRIPTION
Also bump the version number from 0.7.0.1 to 0.7.0.2.