### PR TITLE
Conservative trig functions, conservative recip, and tests for same

### DIFF
--- a/intervals.cabal
+++ b/intervals.cabal
@@ -70,7 +70,9 @@ test-suite doctests
       base,
       directory      >= 1.0,
       doctest        >= 0.9.1,
-      filepath
+      filepath,
+      QuickCheck,
+      template-haskell
 
   if impl(ghc<7.6.1)
     ghc-options: -Werror

--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -57,6 +57,7 @@ main = withUnicode $ getSources >>= \sources -> doctest $
   : "-idist/build/autogen"
   : "-optP-include"
   : "-optPdist/build/autogen/cabal_macros.h"
+  : "-packageQuickCheck"
   : "-hide-all-packages"
   : map ("-package="++) deps ++ sources
 


### PR DESCRIPTION
Resolves issues #20, #23, #21, #32.

Partially resolves #4, by providing doctests that are fairly extensive as to the `NonEmpty` flavor of intervals.