### PR TITLE
Removed redundant import.

### DIFF
--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -50,7 +50,6 @@ module Numeric.Interval.NonEmpty.Internal
 import Control.Exception as Exception
 import Data.Data
 import Data.Foldable hiding (minimum, maximum, elem, notElem)
-import Data.Function (on)
 import Data.Monoid
 #if __GLASGOW_HASKELL__ >= 704
 import GHC.Generics


### PR DESCRIPTION
Not having this change results in a compiler warning about a redundant import since we no longer use `Data.Function.on` in this module. I goofed and failed to notice that earlier.