### PR TITLE
interval integral operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ wip
 *#
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/
+stack.yaml

--- a/src/Numeric/Interval.hs
+++ b/src/Numeric/Interval.hs
@@ -42,6 +42,10 @@ module Numeric.Interval
   , possibly, (<?), (<=?), (==?), (>=?), (>?)
   , idouble
   , ifloat
+  , iquot
+  , irem
+  , idiv
+  , imod
   ) where
 
 import Numeric.Interval.Internal

--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -50,6 +50,10 @@ module Numeric.Interval.Internal
   , possibly, (<?), (<=?), (==?), (>=?), (>?)
   , idouble
   , ifloat
+  , iquot
+  , irem
+  , idiv
+  , imod
   ) where
 
 import Control.Exception as Exception
@@ -927,3 +931,42 @@ ifloat = id
 -- sin 1 :: Interval Double
 
 default (Integer,Double)
+
+-- | The set of all x `quot` y
+iquot :: Integral a => Interval a -> Interval a -> Interval a
+iquot i j = case (i,j) of
+  (Empty,_) -> Empty
+  (_,Empty) -> Empty
+  (I l u , I l' u') ->
+    if l' <= 0 && 0 <= u' then throw DivideByZero else I
+      (minimum [a `quot` b | a <- [l,u], b <- [l',u']])
+      (maximum [a `quot` b | a <- [l,u], b <- [l',u']])
+
+-- | The set of all x `rem` y
+irem :: Integral a => Interval a -> Interval a -> Interval a
+irem i j = case (i,j) of
+  (Empty,_) -> Empty
+  (_,Empty) -> Empty
+  (I l u , I l' u') ->
+    if l' <= 0 && 0 <= u' then throw DivideByZero else I
+      (minimum [0, signum l * (abs u' - 1), signum l * (abs l' - 1)])
+      (maximum [0, signum u * (abs u' - 1), signum u * (abs l' - 1)])
+
+-- | the set of all x `div` y
+idiv :: Integral a => Interval a -> Interval a -> Interval a
+idiv i j = case (i,j) of
+  (Empty,_) -> Empty
+  (_,Empty) -> Empty
+  (I l u , I l' u') ->
+    if l' <= 0 && 0 <= u' then throw DivideByZero else I
+      (min (l `Prelude.div` max 1 l') (u `Prelude.div` min (-1) u'))
+      (max (u `Prelude.div` max 1 l') (l `Prelude.div` min (-1) u'))
+
+-- | the set of all x `mod` y
+imod :: Integral a => Interval a -> Interval a -> Interval a
+imod i j = case (i,j) of
+  (Empty,_) -> Empty
+  (_,Empty) -> Empty
+  (_ , I l' u') ->
+    if l' <= 0 && 0 <= u' then throw DivideByZero else
+      I (min (l'+1) 0) (max 0 (u'-1))

--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -932,7 +932,11 @@ ifloat = id
 
 default (Integer,Double)
 
--- | The set of all x `quot` y
+-- | an interval containing all x `quot` y
+-- >>> (5 `quot` 3) `member` ((4...6) `iquot` (2...4))
+-- True
+-- >>> (1...10) `iquot` ((-5)...4)
+-- *** Exception: divide by zero
 iquot :: Integral a => Interval a -> Interval a -> Interval a
 iquot i j = case (i,j) of
   (Empty,_) -> Empty
@@ -942,7 +946,11 @@ iquot i j = case (i,j) of
       (minimum [a `quot` b | a <- [l,u], b <- [l',u']])
       (maximum [a `quot` b | a <- [l,u], b <- [l',u']])
 
--- | The set of all x `rem` y
+-- | an interval containing all x `rem` y
+-- >>> (5 `rem` 3) `member` ((4...6) `irem` (2...4))
+-- True
+-- >>> (1...10) `irem` ((-5)...4)
+-- *** Exception: divide by zero
 irem :: Integral a => Interval a -> Interval a -> Interval a
 irem i j = case (i,j) of
   (Empty,_) -> Empty
@@ -952,7 +960,11 @@ irem i j = case (i,j) of
       (minimum [0, signum l * (abs u' - 1), signum l * (abs l' - 1)])
       (maximum [0, signum u * (abs u' - 1), signum u * (abs l' - 1)])
 
--- | the set of all x `div` y
+-- | an interval containing all x `div` y
+-- >>> (5 `div` 3) `member` ((4...6) `idiv` (2...4))
+-- True
+-- >>> (1...10) `idiv` ((-5)...4)
+-- *** Exception: divide by zero
 idiv :: Integral a => Interval a -> Interval a -> Interval a
 idiv i j = case (i,j) of
   (Empty,_) -> Empty
@@ -962,7 +974,11 @@ idiv i j = case (i,j) of
       (min (l `Prelude.div` max 1 l') (u `Prelude.div` min (-1) u'))
       (max (u `Prelude.div` max 1 l') (l `Prelude.div` min (-1) u'))
 
--- | the set of all x `mod` y
+-- | an interval containing all x `mod` y
+-- >>> (5 `mod` 3) `member` ((4...6) `imod` (2...4))
+-- True
+-- >>> (1...10) `imod` ((-5)...4)
+-- *** Exception: divide by zero
 imod :: Integral a => Interval a -> Interval a -> Interval a
 imod i j = case (i,j) of
   (Empty,_) -> Empty

--- a/src/Numeric/Interval/Kaucher.hs
+++ b/src/Numeric/Interval/Kaucher.hs
@@ -396,6 +396,10 @@ midpoint x = inf x + (sup x - inf x) / 2
 --
 -- >>> member 8 (1.0 ... 5.0)
 -- False
+--
+-- >>> member 5 empty
+-- False
+--
 member :: Ord a => a -> Interval a -> Bool
 member x (I a b) = x >= a && x <= b
 {-# INLINE member #-}
@@ -407,6 +411,11 @@ member x (I a b) = x >= a && x <= b
 --
 -- >>> notMember 1.4 (1.0 ... 5.0)
 -- False
+--
+-- And of course, nothing is a member of the empty interval.
+--
+-- >>> notMember 5 empty
+-- True
 notMember :: Ord a => a -> Interval a -> Bool
 notMember x xs = not (member x xs)
 {-# INLINE notMember #-}
@@ -424,6 +433,10 @@ notMember x xs = not (member x xs)
 --
 -- >>> elem 8 (1.0 ... 5.0)
 -- False
+--
+-- >>> elem 5 empty
+-- False
+--
 elem :: Ord a => a -> Interval a -> Bool
 elem = member
 {-# INLINE elem #-}
@@ -436,6 +449,11 @@ elem = member
 --
 -- >>> notElem 1.4 (1.0 ... 5.0)
 -- False
+--
+-- And of course, nothing is a member of the empty interval.
+--
+-- >>> notElem 5 empty
+-- True
 notElem :: Ord a => a -> Interval a -> Bool
 notElem = notMember
 {-# INLINE notElem #-}

--- a/src/Numeric/Interval/Kaucher.hs
+++ b/src/Numeric/Interval/Kaucher.hs
@@ -875,28 +875,44 @@ ifloat = id
 
 default (Integer,Double)
 
--- | The set of all x `quot` y
+-- | an interval containing all x `quot` y
+-- >>> (5 `quot` 3) `member` ((4...6) `iquot` (2...4))
+-- True
+-- >>> (1...10) `iquot` ((-5)...4)
+-- *** Exception: divide by zero
 iquot :: Integral a => Interval a -> Interval a -> Interval a
 iquot (I l u) (I l' u') =
   if l' <= 0 && 0 <= u' then throw DivideByZero else I
     (minimum [a `quot` b | a <- [l,u], b <- [l',u']])
     (maximum [a `quot` b | a <- [l,u], b <- [l',u']])
 
--- | The set of all x `rem` y
+-- | an interval containing all x `rem` y
+-- >>> (5 `rem` 3) `member` ((4...6) `irem` (2...4))
+-- True
+-- >>> (1...10) `irem` ((-5)...4)
+-- *** Exception: divide by zero
 irem :: Integral a => Interval a -> Interval a -> Interval a
 irem (I l u) (I l' u') =
   if l' <= 0 && 0 <= u' then throw DivideByZero else I
     (minimum [0, signum l * (abs u' - 1), signum l * (abs l' - 1)])
     (maximum [0, signum u * (abs u' - 1), signum u * (abs l' - 1)])
 
--- | the set of all x `div` y
+-- | an interval containing all x `div` y
+-- >>> (5 `div` 3) `member` ((4...6) `idiv` (2...4))
+-- True
+-- >>> (1...10) `idiv` ((-5)...4)
+-- *** Exception: divide by zero
 idiv :: Integral a => Interval a -> Interval a -> Interval a
 idiv (I l u) (I l' u') =
   if l' <= 0 && 0 <= u' then throw DivideByZero else I
     (min (l `Prelude.div` max 1 l') (u `Prelude.div` min (-1) u'))
     (max (u `Prelude.div` max 1 l') (l `Prelude.div` min (-1) u'))
 
--- | the set of all x `mod` y
+-- | an interval containing all x `mod` y
+-- >>> (5 `mod` 3) `member` ((4...6) `imod` (2...4))
+-- True
+-- >>> (1...10) `imod` ((-5)...4)
+-- *** Exception: divide by zero
 imod :: Integral a => Interval a -> Interval a -> Interval a
 imod _ (I l' u') =
   if l' <= 0 && 0 <= u' then throw DivideByZero else

--- a/src/Numeric/Interval/NonEmpty.hs
+++ b/src/Numeric/Interval/NonEmpty.hs
@@ -48,6 +48,10 @@ module Numeric.Interval.NonEmpty
   , scale, symmetric
   , idouble
   , ifloat
+  , iquot
+  , irem
+  , idiv
+  , imod
   ) where
 
 import Numeric.Interval.NonEmpty.Internal

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -47,6 +47,10 @@ module Numeric.Interval.NonEmpty.Internal
   , scale, symmetric
   , idouble
   , ifloat
+  , iquot
+  , irem
+  , idiv
+  , imod
   ) where
 
 import Control.Exception as Exception
@@ -854,3 +858,30 @@ ifloat = id
 -- sin 1 :: Interval Double
 
 default (Integer,Double)
+
+-- | The set of all x `quot` y
+iquot :: Integral a => Interval a -> Interval a -> Interval a
+iquot (I l u) (I l' u') =
+  if l' <= 0 && 0 <= u' then throw DivideByZero else I
+    (minimum [a `quot` b | a <- [l,u], b <- [l',u']])
+    (maximum [a `quot` b | a <- [l,u], b <- [l',u']])
+
+-- | The set of all x `rem` y
+irem :: Integral a => Interval a -> Interval a -> Interval a
+irem (I l u) (I l' u') =
+  if l' <= 0 && 0 <= u' then throw DivideByZero else I
+    (minimum [0, signum l * (abs u' - 1), signum l * (abs l' - 1)])
+    (maximum [0, signum u * (abs u' - 1), signum u * (abs l' - 1)])
+
+-- | the set of all x `div` y
+idiv :: Integral a => Interval a -> Interval a -> Interval a
+idiv (I l u) (I l' u') =
+  if l' <= 0 && 0 <= u' then throw DivideByZero else I
+    (min (l `Prelude.div` max 1 l') (u `Prelude.div` min (-1) u'))
+    (max (u `Prelude.div` max 1 l') (l `Prelude.div` min (-1) u'))
+
+-- | the set of all x `mod` y
+imod :: Integral a => Interval a -> Interval a -> Interval a
+imod _ (I l' u') =
+  if l' <= 0 && 0 <= u' then throw DivideByZero else
+    I (min (l'+1) 0) (max 0 (u'-1))


### PR DESCRIPTION
- fixes #10 
- added `iquot`, `item`, `idiv`, `mod` for `Interval`,
  `Interval.NonEmpty` and `Interval.Kaucher`
- deprecated `elem`/`notElem` and added `member`/`notMember` to
  `Interval.Kaucher`
