### PR TITLE
Remove Foldable instance from Intervals

### DIFF
--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -58,13 +58,7 @@ module Numeric.Interval.Internal
 
 import Control.Exception as Exception
 import Data.Data
-import Data.Foldable hiding (minimum, maximum, elem, notElem
-#if __GLASGOW_HASKELL__ >= 710
-  , null
-#endif
-  )
 import Data.Function (on)
-import Data.Monoid
 #if __GLASGOW_HASKELL__ >= 704
 import GHC.Generics
 #endif
@@ -84,11 +78,6 @@ data Interval a = I !a !a | Empty deriving
 #endif
 #endif
   )
-
-instance Foldable Interval where
-  foldMap f (I a b) = f a `mappend` f b
-  foldMap _ Empty = mempty
-  {-# INLINE foldMap #-}
 
 infix 3 ...
 infixl 6 +/-

--- a/src/Numeric/Interval/NonEmpty/Internal.hs
+++ b/src/Numeric/Interval/NonEmpty/Internal.hs
@@ -55,8 +55,6 @@ module Numeric.Interval.NonEmpty.Internal
 
 import Control.Exception as Exception
 import Data.Data
-import Data.Foldable hiding (minimum, maximum, elem, notElem)
-import Data.Monoid
 #if __GLASGOW_HASKELL__ >= 704
 import GHC.Generics
 #endif
@@ -90,10 +88,6 @@ data Interval a = I !a !a deriving
 #endif
 #endif
   )
-
-instance Foldable Interval where
-  foldMap f (I a b) = f a `mappend` f b
-  {-# INLINE foldMap #-}
 
 infix 3 ...
 


### PR DESCRIPTION
Foldable exports too many confusing methods that don't do what you think 
for intervals:

Ex.
toList (1...5) = [1,5]
elem 2 (1...5) = False
length (1...5) = 2
length (1...1) = 2