### PR TITLE
fix sin/cos and (/) behavior

### DIFF
--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -529,8 +529,8 @@ instance (Fractional a, Ord a) => Fractional (Interval a) where
   x / y@(I a b)
     | 0 `notElem` y = divNonZero x y
     | iz && sz  = Exception.throw DivideByZero
-    | iz        = divPositive x a
-    |       sz  = divNegative x b
+    | iz        = divPositive x b
+    |       sz  = divNegative x a
     | otherwise = divZero x
     where
       iz = a == 0

--- a/src/Numeric/Interval/Internal.hs
+++ b/src/Numeric/Interval/Internal.hs
@@ -567,6 +567,7 @@ instance (RealFloat a, Ord a) => Floating (Interval a) where
   cos x
     | width t >= pi = (-1) ... 1
     | inf t >= pi = - cos (t - pi)
+    | inf t < 0 = - cos (t + pi)
     | sup t <= pi = decreasing cos t
     | sup t <= 2 * pi = (-1) ... cos ((pi * 2 - sup t) `min` inf t)
     | otherwise = (-1) ... 1


### PR DESCRIPTION
This hopefully resolves #59 by constraining the infimum in `cos` to [0, pi).

It also changes (/) to improve behavior with zero end points (see #19 ). Before:
```
> 1.0 / (0.0 ... 1.0)
Infinity ... Infinity
> 1.0 / (-1.0 ... 0.0)
-Infinity ... Infinity
```

After:
```
> 1.0 / (0.0 ... 1.0)
1.0 ... Infinity
> 1.0 / (-1.0 ... 0.0)
-Infinity ...-1.0
```

For what it's worth, the new behavior is consistent with the Multiple Precision Floating-Point Interval (MPFI) library. Because there might be opinions, I didn't touch `1 / singleton 0.0` (e.g., #47), but MPFI does return `whole` for that, rather than an exception.

Also do you have any interest in defining `recip` in terms of `(/)`?  I thought there might be a reason `recip` is defined as is, but if not, redefining `recip` would fix #53.

Finally, I am a novice to Haskell so all of this might benefit from a second set of eyes.

Thanks for the help and putting together this package!

Adam

**EDIT**: I am leaving this pull request open for now, but I also have a branch going:

[https://github.com/massma/intervals/tree/adam-fork](https://github.com/massma/intervals/tree/adam-fork)

of some (possibly opinionated and novice) changes I made to address the bugs I needed to for my application. So far this branch fixes #19, #47, #53, #59, #61. If you want any of these updates to be incorporated into `intervals` just let me know: I am happy to filter and edit the branch according to your preferences, and submit a fresh pull request!